### PR TITLE
Changed the signature of `IdentityMap.finalize!`

### DIFF
--- a/spec/praxis-mapper/identity_map_spec.rb
+++ b/spec/praxis-mapper/identity_map_spec.rb
@@ -304,6 +304,24 @@ describe Praxis::Mapper::IdentityMap do
       identity_map.finalize!(instrument: false)
     end
 
+    context 'plays well with Sequel models' do
+      # The reason to test agains Sequel models is that the destructuring of args
+      # for the _finalize! call caused unexpecting "loads" due to invoking .to_hash on them, see function for details
+      it 'calls the _finalize! with just the one model passed' do
+        identity_map.should_receive(:_finalize!).with(UserModel)
+         identity_map.finalize!(UserModel)
+      end
+
+      it 'calls the _finalize! with just the models passed' do
+        identity_map.should_receive(:_finalize!).with(UserModel,PostModel)
+         identity_map.finalize!(UserModel,PostModel)
+      end
+
+      it 'calls the _finalize! discarding instrument opts' do
+        identity_map.should_receive(:_finalize!).with(UserModel)
+        identity_map.finalize!(UserModel, instrument: false)
+      end
+    end
   end
 
   context "#finalize_model!" do


### PR DESCRIPTION
Changed the signature of `IdentityMap.finalize!`:

* Trying to restructure params as (*models,instrument:true) causes Ruby to call .to_hash (or some derivate of it) method on the models, which, if they are Sequel Models causes loading of data from the DB.
* Changed the signature to handle the `instrument` option in the code instead, for make sure Ruby doesn’t call unexpected methods on the passed models. 


Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>