### PR TITLE
Remove finalizer from IdentityMap to fix memory leak that was preventing them from being GC'd properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+* Remove finalizer from IdentityMap to fix memory leak that was preventing them from being GC'd properly.
+
+
 ## 4.1.1
 
 * Fixed critical bug in `IdentityMap#finalize!`=

--- a/lib/praxis-mapper/connection_factories/sequel.rb
+++ b/lib/praxis-mapper/connection_factories/sequel.rb
@@ -39,7 +39,7 @@ module Praxis::Mapper
 
       def release(connection_manager, connection)
         # ensure we only release connections we own, in case
-        # we've acquired a connection from Sequel that 
+        # we've acquired a connection from Sequel that
         # is likely still in use.
         if (@owned_connections.delete(connection_manager.thread))
           @connection.pool.send(:sync) do
@@ -50,9 +50,9 @@ module Praxis::Mapper
 
       def acquire(thread)
         # check connection's pool to see if it already has a connection
-        # if so, re-use it. otherwise, acquire a new one and mark that we 
+        # if so, re-use it. otherwise, acquire a new one and mark that we
         # "own" it for future releasing.
-        if (owned = @connection.pool.send(:owned_connection, thread))
+        if @connection.pool.send(:owned_connection, thread)
           return true
         else
           conn = @connection.pool.send(:acquire, thread)

--- a/lib/praxis-mapper/connection_manager.rb
+++ b/lib/praxis-mapper/connection_manager.rb
@@ -17,7 +17,7 @@ module Praxis::Mapper
 
       query = data[:query] || Praxis::Mapper::Query::Sql
       factory_class = data[:factory] || ConnectionFactories::Simple
-      
+
       opts = data[:opts] || {}
       if query.kind_of? String
         query = query.constantize
@@ -26,14 +26,14 @@ module Praxis::Mapper
       if factory_class.kind_of? String
         factory_class = factory_class.constantize
       end
-      
+
       repositories[repository_name] = {
         query: query,
         factory: factory_class.new(**opts, &block)
       }
     end
 
-    
+
     def repositories
       self.class.repositories
     end
@@ -73,7 +73,7 @@ module Praxis::Mapper
         release_one(name)
       else
         names = @connections.keys
-        names.each { |name| release_one(name) }
+        names.each { |n| release_one(n) }
       end
     end
 

--- a/lib/praxis-mapper/identity_map.rb
+++ b/lib/praxis-mapper/identity_map.rb
@@ -70,11 +70,6 @@ module Praxis::Mapper
       @connection_manager = ConnectionManager.new
       @scope = scope
       clear!
-
-      # Ensure we clean up open connections
-      ObjectSpace.define_finalizer(self) do
-        @connection_manager.release
-      end
     end
 
     def clear!


### PR DESCRIPTION
Signed-off-by: Dane Jensen <dane@rightscale.com>