### PR TITLE
A couple of fixes to `Query::Sequel`:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.1.2
-  - 2.2.2
+  - 2.2.3
+  - 2.3.1
 script: bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * Fixed `SystemStackError` from `IdentityMap#add_selectors` if the provided
   field hashes are self-referencing. I.e. `{author: {posts: {author: {...}}}}`
 * Fixed `SystemStackError` from `SelectorGenerator` for circular `Resource.property` definitions like `property :foo, dependencies: [:foo, :bar]`.
-
+* Fixed `Query::Sequel` not working with raw SQL queries.
+* Fixed SQL logging in `Query::Sequel` for query execution passing a dataset.
 
 ## 4.2
 

--- a/lib/praxis-mapper/query/sequel.rb
+++ b/lib/praxis-mapper/query/sequel.rb
@@ -52,7 +52,7 @@ module Praxis::Mapper
       #
       # @return [Array] result-set
       def _execute(ds=nil)
-        Praxis::Mapper.logger.debug "SQL:\n#{self.describe}\n"
+        Praxis::Mapper.logger.debug "SQL:\n#{self.describe(ds)}\n"
         self.statistics[:datastore_interactions] += 1
         start_time = Time.now
 
@@ -60,7 +60,7 @@ module Praxis::Mapper
           unless ds.nil?
             warn 'WARNING: Query::Sequel#_execute ignoring passed dataset due to previously-specified raw SQL'
           end
-          connection.run(@raw_query).to_a
+          connection[@raw_query].to_a
         else
           (ds || self.dataset).to_a
         end
@@ -70,8 +70,8 @@ module Praxis::Mapper
       end
 
       # @see #sql
-      def describe
-        self.sql
+      def describe(ds=nil)
+        (ds || self).sql
       end
 
       # Constructs a raw SQL statement.


### PR DESCRIPTION
* Fixed `Query::Sequel` not working with raw SQL queries.
* Fixed SQL logging in `Query::Sequel` for query execution passing a dataset.

Signed-off-by: Josep M. Blanquer <blanquer@gmail.com>